### PR TITLE
ci: adopt org docker-image-ci meta for lint & security

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+# Adopts the org "Docker Image CI" gold-standard meta for the LINT +
+# SECURITY surface (hadolint, shellcheck, yamllint, compose config-check,
+# a validation-only Trivy build of the primary Moodle image, secret
+# scanning and dependency review).
+#
+# The bespoke two-image build (build-moodle-image + build-nginx-image) and
+# the Test Stack Startup live in docker-build.yml and are intentionally NOT
+# subsumed here: build-container validates ONE image/Dockerfile, so this
+# call points it at the primary Moodle Dockerfile. The nginx Dockerfile and
+# the full stack integration test remain covered by docker-build.yml.
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions: {}
+
+jobs:
+  lint-security:
+    name: Lint & Security
+    uses: netresearch/.github/.github/workflows/docker-image-ci.yml@main
+    permissions:
+      contents: read
+      packages: write
+      security-events: write
+      id-token: write
+      attestations: write
+      actions: read
+      pull-requests: write
+    with:
+      image-name: moodle
+      dockerfile: ./docker/moodle/Dockerfile
+      context: ./docker/moodle
+      lint-container: true
+      shell-scandirs: "docker scripts"
+      lint-yaml: true
+      lint-compose: true
+      compose-files: "compose.yml"
+    secrets:
+      GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,4 @@
+ignored:
+  # Alpine's apk repositories serve a single package version at a time, so
+  # pinning every apk package is impractical and churns on every base bump.
+  - DL3018

--- a/docker/moodle/Dockerfile
+++ b/docker/moodle/Dockerfile
@@ -22,7 +22,7 @@ ARG RUNTIME_DEPS="bash curl git unzip \
 RUN apk add --no-cache $RUNTIME_DEPS $BUILD_DEPS \
     && docker-php-ext-configure gd --with-freetype --with-jpeg \
     && docker-php-ext-configure ldap \
-    && docker-php-ext-install -j$(nproc) \
+    && docker-php-ext-install -j"$(nproc)" \
         mysqli pdo_mysql \
         pgsql pdo_pgsql \
         gd \

--- a/docker/moodle/entrypoint.sh
+++ b/docker/moodle/entrypoint.sh
@@ -69,8 +69,9 @@ download_moodle() {
     local version="$1"
 
     # Extract major.minor for stable branch (e.g., 5.1.2 -> 501)
-    local major=$(echo "$version" | cut -d. -f1)
-    local minor=$(echo "$version" | cut -d. -f2)
+    local major minor
+    major=$(echo "$version" | cut -d. -f1)
+    minor=$(echo "$version" | cut -d. -f2)
     local stable_branch="${major}0${minor}"
 
     log "Downloading Moodle ${version} (stable${stable_branch})..."
@@ -240,5 +241,5 @@ generate_config
 # Fix permissions
 fix_permissions
 
-log "Bootstrap complete, starting: $@"
+log "Bootstrap complete, starting: $*"
 exec "$@"

--- a/scripts/push-to-github.sh
+++ b/scripts/push-to-github.sh
@@ -124,9 +124,7 @@ git remote -v
 echo -e "\n${GREEN}Pushing to GitHub...${NC}"
 echo -e "${YELLOW}Note: This requires SSH key access to github.com/netresearch/${NC}\n"
 
-git push -u origin main
-
-if [ $? -eq 0 ]; then
+if git push -u origin main; then
     echo -e "\n${GREEN}=== SUCCESS ===${NC}"
     echo -e "${GREEN}Repository pushed to: https://github.com/${ORG}/${REPO_NAME}${NC}"
     echo -e "\n${YELLOW}Next steps:${NC}"


### PR DESCRIPTION
## What

Adopts the org **`docker-image-ci.yml@main`** meta for the **lint + security** surface, without disturbing the bespoke build. New `.github/workflows/ci.yml` calls the meta with one job (`lint-security`):

- **lint-container** (hadolint on the primary Moodle Dockerfile + shellcheck over `docker` / `scripts`)
- **lint-yaml**
- **lint-compose** (`compose.yml`; `.env.example` is auto-copied by the reusable so placeholders resolve)
- **build (validation)** — `push: false`, single-arch, Trivy scan of the Moodle image
- **gitleaks** secret scanning (GITLEAKS_LICENSE forwarded explicitly, no `secrets: inherit`)
- **dependency-review** (PR only)

## Scope decisions

- `build-container` validates **one** image/Dockerfile, so it is pointed at the **primary** Moodle Dockerfile (`docker/moodle/Dockerfile`). The meta's `build` job is not gated by an enable flag, so a single image target is required.
- The bespoke **two-image build** (`build-moodle-image` + `build-nginx-image`) and the **Test Stack Startup** in `docker-build.yml` are **left untouched**. The nginx Dockerfile and the full-stack integration test stay covered there.
- Markdown lint is not enabled here (already handled by the existing `markdown-lint` job).

## Mechanical lint debt fixed (prerequisite for the new lint surface)

- `docker/moodle/Dockerfile`: quote `$(nproc)` (SC2046)
- `docker/moodle/entrypoint.sh`: split declare/assign for locals (SC2155); `$*` in the bootstrap log line (SC2145 error)
- `scripts/push-to-github.sh`: check the push exit code directly (SC2181)
- add `.hadolint.yaml` ignoring `DL3018` (Alpine apk serves a single package version; pinning is impractical)

## Known coverage gap

The meta's `lint-container` hadolints only the **one** Dockerfile passed to it (Moodle). The **nginx Dockerfile is not hadolinted** by this meta — it stays validated via `nginx -t` in the bespoke build.
