### PR TITLE
ci: call the shared auto-merge reusable

### DIFF
--- a/.github/workflows/auto-merge-deps.yml
+++ b/.github/workflows/auto-merge-deps.yml
@@ -1,73 +1,22 @@
-# Auto-merge dependency updates for repositories WITHOUT branch protection
-# Uses direct merge since --auto flag requires branch protection
 name: Auto-merge dependency PRs
 
 on:
   pull_request_target:
     types: [opened, synchronize, reopened]
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
+# Thin caller: the whole gate lives in the shared reusable, so the pinned
+# action versions and the merge policy stay maintained centrally.
+#
+# This repo has auto-merge enabled, so the reusable hands the merge to
+# GitHub and lets it hold until the required checks pass. The local copy
+# this replaces polled the checks itself and merged directly, on the stated
+# grounds of being a "repository WITHOUT branch protection" — which is not
+# true here: the repo has branch protection and allow_auto_merge=true.
 jobs:
   auto-merge:
-    name: Auto-merge dependency PRs
-    runs-on: ubuntu-latest
-    # Use PR author login instead of github.actor to handle synchronize events
-    # when someone else pushes to the dependabot/renovate branch
-    if: github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'renovate[bot]'
-
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
-        with:
-          egress-policy: audit
-
-      - name: Dependabot metadata
-        id: metadata
-        if: github.event.pull_request.user.login == 'dependabot[bot]'
-        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
-        with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-
-      - name: Auto-approve PR
-        run: gh pr review --approve "$PR_URL"
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Wait for CI checks
-        run: |
-          echo "Waiting for CI checks to complete..."
-          for i in {1..90}; do
-            CHECKS=$(gh pr checks "$PR_URL" --json name,state \
-              --jq '[.[] | select(.name != "Auto-merge dependency PRs")]')
-
-            FAILED=$(echo "$CHECKS" | jq '[.[] | select(.state == "FAILURE" or .state == "ERROR")] | length')
-            PENDING=$(echo "$CHECKS" | jq '[.[] | select(.state == "PENDING" or .state == "QUEUED" or .state == "IN_PROGRESS")] | length')
-
-            if [ "$FAILED" != "0" ]; then
-              echo "Some checks failed, skipping merge"
-              exit 1
-            fi
-
-            if [ "$PENDING" = "0" ]; then
-              echo "All checks passed!"
-              exit 0
-            fi
-
-            echo "Waiting for $PENDING check(s)... (attempt $i/90)"
-            sleep 10
-          done
-          echo "Timeout waiting for checks"
-          exit 1
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Merge PR
-        run: gh pr merge --merge "$PR_URL"
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    uses: netresearch/.github/.github/workflows/auto-merge-deps.yml@main
+    permissions:
+      contents: write
+      pull-requests: write


### PR DESCRIPTION
Replaces a 60-line local copy of the auto-merge workflow with a four-line caller. Net **-64/+13**.

> **Correction to the original description of this PR.** It claimed the shared reusable "hands the merge to GitHub via `--auto`, which holds it until the required checks pass". That was wrong for this repo, and merging on that basis would have **removed the CI gate for dependency PRs**. Details below.

### What the local copy actually protected

The copy polled the checks in a bash loop and refused to merge when any reported `FAILURE`/`ERROR`. Its header justified this as being for *"repositories WITHOUT branch protection"* — that part **is** stale, this repo has protection:

```
allow_auto_merge          = true
branch protection on main = yes  (required_conversation_resolution)
required_status_checks    = null      <-- none
rulesets                  = 0
```

But the conclusion drawn from the stale header was wrong in the other direction. GitHub-native auto-merge only holds a merge for **required** status checks. This branch requires none, so `--auto` would not have waited for `CI`, `Docker Build & Validate` or `Security` — they are all optional contexts. The polling loop was the only thing keeping a red dependency bump from landing. That is a genuine functional requirement, not a local quirk.

### What changed instead

Rather than leaving the copy in place, the shared reusable was fixed to detect this: it now checks whether the base branch genuinely has required status checks before delegating to `--auto`, and gates on the checks itself when it cannot prove a gate exists ([netresearch/.github#290](https://github.com/netresearch/.github/pull/290), on top of [#289](https://github.com/netresearch/.github/pull/289)).

With that in place this repo takes the **self-gating** path — the same behaviour as the local copy it replaces: wait for the checks, merge if they pass, leave the PR approved-but-open if they do not.

### Merge order

This PR must not merge before [netresearch/.github#290](https://github.com/netresearch/.github/pull/290).