### PR TITLE
chore: stop forwarding the deprecated GITLEAKS_LICENSE secret

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,5 +38,3 @@ jobs:
       lint-yaml: true
       lint-compose: true
       compose-files: "compose.yml"
-    secrets:
-      GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -9,8 +9,6 @@ on:
 jobs:
   gitleaks:
     uses: netresearch/.github/.github/workflows/gitleaks.yml@main
-    secrets:
-      GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
 
   dependency-review:
     if: github.event_name == 'pull_request'


### PR DESCRIPTION
Removes the `GITLEAKS_LICENSE` mapping this workflow passes into the shared secret-scanning reusable.

Secret scanning runs on **betterleaks**, which is OSS and needs no licence. The reusable declares `GITLEAKS_LICENSE` purely for backwards compatibility and **never reads it** — and the org-level secret has since been deleted, so what this workflow forwards today is an empty string into an input that ignores it.

Only the mapping line is removed. The enclosing `secrets:` key is dropped only where nothing else remained under it; any other secret in the same block is untouched.

Part of finishing the betterleaks/zizmor rollout (netresearch/.github#327, #330). Once no caller forwards the secret, the compatibility declarations in the reusables can be removed too.
